### PR TITLE
Fix nvjitlink doc link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # <div align="left"><img src="https://rapids.ai/assets/images/rapids_logo.png" width="90px"/>&nbsp;pynvjitlink</div>
 
 The [RAPIDS](https://rapids.ai) pynvjitlink library provides a Python binding for the
-[nvJitLink library](https://docs.nvidia.com/cuda/nvJitLink/index.html).
+[nvJitLink library](https://docs.nvidia.com/cuda/nvjitlink/index.html).
 
 ## Installation with pip
 


### PR DESCRIPTION
I noticed that the link to nvjitlink in README.md isn't working, this PR fixes that.
