### PR TITLE
Patch pynvjitlink to allow linking nvrtc compiled ltoir

### DIFF
--- a/pynvjitlink/_nvjitlinklib.cpp
+++ b/pynvjitlink/_nvjitlinklib.cpp
@@ -79,6 +79,7 @@ static PyObject *create(PyObject *self, PyObject *args) {
     }
 
     jitlink_options[i] = PyUnicode_AsUTF8AndSize(py_option, nullptr);
+    printf("Jitlink option %ld: %s\n", i, jitlink_options[i]);
   }
 
   try {
@@ -144,6 +145,17 @@ static PyObject *add_data(PyObject *self, PyObject *args) {
 
   const void *data = buf.buf;
   size_t size = buf.len;
+
+  {
+    printf("Data Name: %s\n", name);
+    printf("Input type: %d\n", static_cast<int>(input_type));
+    const unsigned char *data_str = static_cast<const unsigned char *>(data);
+    for (size_t i = 0; i < size; ++i) {
+      printf("%02x ", data_str[i]);
+    }
+    printf("\n");
+  }
+
   nvJitLinkResult res =
       nvJitLinkAddData(*jitlink, input_type, data, size, name);
 

--- a/pynvjitlink/api.py
+++ b/pynvjitlink/api.py
@@ -1,9 +1,12 @@
 # Copyright (c) 2023, NVIDIA CORPORATION.
 
+import os
 from enum import Enum
 from pynvjitlink import _nvjitlinklib
 
 import weakref
+
+from numba.cuda.cudadrv.driver import FILE_EXTENSION_MAP
 
 
 class InputType(Enum):

--- a/pynvjitlink/patch.py
+++ b/pynvjitlink/patch.py
@@ -124,7 +124,6 @@ class PatchedLinker(Linker):
         if additional_flags is not None:
             options.extend(additional_flags)
 
-        print(options)
         self._linker = NvJitLinker(*options)
         self.options = options
 


### PR DESCRIPTION
When a user provide a cuda source file, by default nvrtc_compile compiles it to PTX. In a separate [PR](https://github.com/gmarkall/numba/pull/5), I made it possible for `nvrtc_compile` to generate ltoir. This PR enables pynvjitlink to link that compiled ltoir.